### PR TITLE
Citation File Format (CFF) v1.2.0 support

### DIFF
--- a/.github/workflows/R-check.yml
+++ b/.github/workflows/R-check.yml
@@ -1,12 +1,19 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
+# usethis::use_github_action("check-standard") will install it.
 on: [push, pull_request]
 
-name: R-check
+
+name: R-CMD-check
 
 jobs:
-  R-check:
+  R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }} ${{ matrix.config.v8 }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
       fail-fast: false
@@ -16,72 +23,58 @@ jobs:
         - { os: macOS-latest, r: 'oldrel', args: "--no-manual"}
         - { os: macOS-latest, r: 'release'}
         - { os: macOS-latest, r: 'devel'}
-        - { os: ubuntu-16.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+        - { os: ubuntu-18.04, r: 'release'}
+        - { os: ubuntu-20.04, r: 'release'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      CRAN: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
+      - uses: r-lib/actions/setup-tinytex@v1
+
+      - name: Install V8
+        if: runner.os == 'Linux' && matrix.config.os != 'ubuntu-18.04'
+        run: |
+          sudo apt-get install -y libv8-dev
+
+      - name: Install V8 on old ubuntu
+        if: runner.os == 'Linux' && matrix.config.os == 'ubuntu-18.04'
+        run: |
+          # Ubuntu Xenial (16.04) and Bionic (18.04) only
+          sudo add-apt-repository ppa:cran/v8
+          sudo apt-get update
+          sudo apt-get install libnode-dev
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-tinytex@v1
-        if: contains(matrix.config.args, 'no-manual') == false
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - name: Install linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get -y update
-          sudo apt-get install -y --no-install-recommends libv8-dev
-
-      - name: Install macos system dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install v8
-
-      - name: Install dependencies
-        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran(c('rcmdcheck', 'bibtex'))"
-
-      - name: Session info
-        run: |
-          options(width = 100)
-          pkgs <- installed.packages()[, "Package"]
-          sessioninfo::session_info(pkgs, include_base = TRUE)
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: rcmdcheck
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '${{ matrix.config.args }}'), error_on = 'warning', check_dir = 'check')"
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@main
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
-
-      - name: Test coverage
-        if: matrix.config.os == 'ubuntu-16.04' && matrix.config.r == 'release'
-        run: |
-          Rscript -e 'remotes::install_github("r-lib/covr@gh-actions")'
-          Rscript -e 'covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,26 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on: [push, pull_request]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: covr
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/R/cff_reader.R
+++ b/R/cff_reader.R
@@ -27,7 +27,7 @@
 #' https://github.com/citation-file-format/citation-file-format#person-objects
 #' - title must be a string
 #' @examples
-#' (z <- system.file('extdata/citation.cff', package = "handlr"))
+#' (z <- system.file("extdata/citation.cff", package = "handlr"))
 #' res <- cff_reader(x = z)
 #' res
 #' res$cff_version
@@ -40,7 +40,7 @@
 #' res$references
 #'
 #' # no references
-#' (z <- system.file('extdata/citation-norefs.cff', package = "handlr"))
+#' (z <- system.file("extdata/citation-norefs.cff", package = "handlr"))
 #' out <- cff_reader(x = z)
 #' out
 #' out$references
@@ -50,19 +50,22 @@ cff_reader <- function(x) {
   structure(cff_read_one(txt),
     class = "handl", from = "cff",
     source_type = if (is_file(x)) "file" else "string",
-    file = if (is_file(x)) x else "", many = FALSE)
+    file = if (is_file(x)) x else "", many = FALSE
+  )
 }
 
 cff_read_one <- function(x) {
   doi <- x$doi
   author <- lapply(req(x$authors, "authors"), function(z) {
-    list(
+    l <- list(
       type = "Person",
       name = pcsp(pcsp(z$`given-names`), pcsp(z$`family-names`)),
       givenName = pcsp(z$`given-names`),
       familyName = pcsp(z$`family-names`),
       orcid = pcsp(z$orcid)
     )
+    # Clean keys with no value
+    l[unlist(lapply(l, function(x) x != ""))]
   })
   state <- if (!is.null(doi)) "findable" else "not_found"
   type <- "SoftwareSourceCode"
@@ -109,16 +112,20 @@ cff_read_one <- function(x) {
 }
 
 process_refs <- function(w) {
-  if (is.null(w)) return(NULL)
+  if (is.null(w)) {
+    return(NULL)
+  }
 
   # check that required fields are given
-  cff_required_nms <- c('type', 'authors', 'title')
+  cff_required_nms <- c("type", "authors", "title")
   cff_required_nms_c <- paste0(cff_required_nms, collapse = ", ")
   for (i in seq_along(w)) {
     mtch <- all(cff_required_nms %in% names(w[[i]]))
     if (!mtch) {
-      stop("reference ", i, " malformed; must have required fields: ",
-        cff_required_nms_c)
+      stop(
+        "reference ", i, " malformed; must have required fields: ",
+        cff_required_nms_c
+      )
     }
   }
 
@@ -131,15 +138,20 @@ process_refs <- function(w) {
   if (!all(mtch_type)) {
     stop("these reference types not in allowed set: ",
       paste0(types[!mtch_type], collapse = ", "),
-      " (see ?cff_reader)", call. = FALSE)
+      " (see ?cff_reader)",
+      call. = FALSE
+    )
   }
 
   # check that authors is a list of type entity's or person's
   auths <- unlist(lapply(w, "[[", "authors"), FALSE)
   for (i in auths) {
-    if (!is_cff_entity(i) && !is_cff_person(i))
+    if (!is_cff_entity(i) && !is_cff_person(i)) {
       stop("each element in 'authors' must be of type entity or person\n",
-        "  see ?cff_reader Details", call. = FALSE)
+        "  see ?cff_reader Details",
+        call. = FALSE
+      )
+    }
   }
 
   return(w)
@@ -152,8 +164,8 @@ is_cff_entity <- function(x) {
 }
 is_cff_person <- function(x) {
   is.list(x) &&
-  is_named(x) &&
-  all(c("family-names", "given-names") %in% names(x))
+    is_named(x) &&
+    all(c("family-names", "given-names") %in% names(x))
 }
 
 # CFF_TO_CP_TRANSLATIONS <- list(

--- a/R/cff_writer.R
+++ b/R/cff_writer.R
@@ -17,12 +17,18 @@
 #' `handl` object is easy: it's really just an R list so add
 #' named elements to it. The required CFF fields are:
 #'
-#' - cff-version: add `cff_version`
-#' - message: add `message`
-#' - version: add `software_version`
-#' - title: add `title`
-#' - authors: add `author`
-#' - date-released: add `date_published`
+#' - CFF **v1.1.0**:
+#'   - cff-version: add `cff_version`
+#'   - message: add `message`
+#'   - version: add `software_version`
+#'   - title: add `title`
+#'   - authors: add `author`
+#'   - date-released: add `date_published`
+#' - CFF **v1.2.0**:
+#'   - Only fields `cff-version`, `message`, `title` and `authors` are
+#'   required.
+#'
+#' If `cff_version` is not provided, the value by default is "1.2.0".
 #'
 #' @examples
 #' (z <- system.file('extdata/citation.cff', package = "handlr"))
@@ -55,15 +61,26 @@ cff_writer <- function(z, path = NULL) {
 }
 
 cff_write_one <- function(z, path) {
+
+  cff_v <- req(z$cff_version %||% cff_version, "cff_version")
+
   zz <- ccp(list(
-    'cff-version' = req(z$cff_version %||% cff_version, "cff-version"),
+    'cff-version' = cff_v,
     message = req(z$message, "message"),
-    version = req(z$software_version, "version"),
+    version = if (cff_v == "1.2.0") {
+      z$software_version
+    } else {
+      req(z$software_version, "date-released")
+    },
     title = req(
       parse_attributes(z$title, content = "text", first = TRUE), "title"),
     authors = req(cff_auths(z$author), "authors"),
     doi = z$doi,
-    'date-released' = req(z$date_published, "date-released"),
+    'date-released' = if (cff_v == "1.2.0") {
+      z$date_published
+    } else {
+      req(z$date_published, "date-released")
+    },
     url = z$b_url,
     keywords = z$keywords,
     references = z$references
@@ -95,7 +112,7 @@ req <- function(x, var) {
   return(x)
 }
 
-cff_version <- "1.1.0"
+cff_version <- "1.2.0"
 
 cff_person_fields <- c(
   "family-names",

--- a/R/cff_writer.R
+++ b/R/cff_writer.R
@@ -8,22 +8,22 @@
 #' @family cff
 #' @references CFF format:
 #' https://github.com/citation-file-format/citation-file-format
-#' @details uses `yaml::write_yaml` to write to yaml format that 
+#' @details uses `yaml::write_yaml` to write to yaml format that
 #' CFF uses
 #' @section Converting to CFF from other formats:
 #' CFF has required fields that can't be missing. This means that
 #' converting from other citation types to CFF will likely require
-#' adding the required CFF fields manually. Adding fields to a 
+#' adding the required CFF fields manually. Adding fields to a
 #' `handl` object is easy: it's really just an R list so add
 #' named elements to it. The required CFF fields are:
-#' 
+#'
 #' - cff-version: add `cff_version`
 #' - message: add `message`
 #' - version: add `software_version`
 #' - title: add `title`
 #' - authors: add `author`
 #' - date-released: add `date_published`
-#' 
+#'
 #' @examples
 #' (z <- system.file('extdata/citation.cff', package = "handlr"))
 #' res <- cff_reader(x = z)
@@ -35,7 +35,7 @@
 #' cff_writer(res, f)
 #' readLines(f)
 #' unlink(f)
-#' 
+#'
 #' # convert from a different citation format
 #' ## see "Converting to CFF from other formats" above
 #' z <- system.file('extdata/citeproc.json', package = "handlr")
@@ -89,7 +89,7 @@ cff_auths <- function(e) {
 
 # check for required variables for CFF
 req <- function(x, var) {
-  if (is.null(x) || length(x) == 0 || !nzchar(x)) {
+  if (is.null(x) || length(x) == 0 || any(!nzchar(x))) {
     stop("'", var, "' is required", call. = FALSE)
   }
   return(x)

--- a/inst/extdata/citation_1.2.0.cff
+++ b/inst/extdata/citation_1.2.0.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+authors:
+  - family-names: Druskat
+    given-names: Stephan
+    orcid: https://orcid.org/0000-0003-4925-7248
+title: "My Research Software"
+doi: 10.5281/zenodo.1234
+keywords:
+  - "McAuthor's algorithm"
+  - linguistics
+  - nlp
+  - parser
+references:
+  - type: book
+    authors:
+      - family-names: Doe
+        given-names: Jane
+      - name: "Foo Bar Working Group"
+        website: https://foo-bar.com
+    title: The science of citation
+  - type: software
+    authors:
+      - family-names: Doe
+        given-names: John
+    title: Software Citation Tool

--- a/inst/extdata/citation_1.2.0_project.cff
+++ b/inst/extdata/citation_1.2.0_project.cff
@@ -1,0 +1,115 @@
+########################################################################################
+# CITATION v1.2,0 file of the CFF project
+# https://github.com/citation-file-format/citation-file-format/blob/1.2.0/CITATION.cff
+########################################################################################
+cff-version: 1.2.0
+message: "If you use CFF in your research, please cite it using these metadata."
+abstract: CITATION.cff files are plain text files with human- and machine-readable citation information for software. Code developers can include them in their repositories to let others know how to correctly cite their software. This is the specification for the Citation File Format.
+authors:
+  - family-names: Druskat
+    given-names: Stephan
+    orcid: https://orcid.org/0000-0003-4925-7248
+  - family-names: Spaaks
+    given-names: Jurriaan H.
+    orcid: https://orcid.org/0000-0002-7064-4069
+  - family-names: Chue Hong
+    given-names: Neil
+    orcid: https://orcid.org/0000-0002-8876-7606
+  - family-names: Haines
+    given-names: Robert
+    orcid: https://orcid.org/0000-0002-9538-7919
+  - family-names: Baker
+    given-names: James
+    orcid: https://orcid.org/0000-0002-2682-6922
+  - family-names: Bliven
+    given-names: Spencer
+    orcid: https://orcid.org/0000-0002-1200-1698
+    email: spencer.bliven@gmail.com
+  - family-names: Willighagen
+    given-names: Egon
+    orcid: https://orcid.org/0000-0001-7542-0286
+  - family-names: Pérez-Suárez
+    given-names: David
+    orcid: https://orcid.org/0000-0003-0784-6909
+    website: https://dpshelio.github.io
+  - family-names: Konovalov
+    given-names: Alexander
+    orcid: https://orcid.org/0000-0001-5299-3292
+title: Citation File Format
+version: 1.2.0
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.1003149
+    description: The concept DOI for the collection containing all versions of the Citation File Format.
+  - type: doi
+    value: 10.5281/zenodo.5171937
+    description: The versioned DOI for the version 1.2.0 of the Citation File Format.
+date-released: "2021-08-09"
+keywords:
+  - citation file format
+  - CFF
+  - citation files
+  - software citation
+  - file format
+  - YAML
+  - software sustainability
+  - research software
+  - credit
+license: "CC-BY-4.0"
+references:
+  - authors:
+      - family-names: Smith
+        given-names: Arfon M.
+      - family-names: Katz
+        given-names: Daniel S.
+      - family-names: Niemeyer
+        given-names: Kyle E.
+      - name: "FORCE11 Software Citation Working Group"
+    doi: 10.7717/peerj-cs.86
+    journal: "PeerJ Computer Science"
+    month: 9
+    start: e86
+    title: "Software citation principles"
+    type: article
+    volume: 2
+    year: 2016
+  - authors:
+      - family-names: Druskat
+        given-names: Stephan
+    conference:
+        name: "Workshop on Sustainable Software for Science: Practice and Experiences (WSSSPE5.1)"
+    doi: 10.6084/m9.figshare.3827058
+    title: "Track 2 Lightning Talk: Should CITATION files be standardized?"
+    type: proceedings
+    year: 2017
+  - authors:
+      - family-names: Wilson
+        given-names: Robin
+    title: "Encouraging citation of software - introducing CITATION files."
+    type: blog
+    url: "https://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files"
+    year: 2013
+  - authors:
+      - family-names: Ben-Kiki
+        given-names: Oren
+      - family-names: Evans
+        given-names: Clark
+      - family-names: "döt Net"
+        given-names: Ingy
+    title: "YAML Ain't Markup Language (YAML) Version 1.2. 3rd Edition, Patched at 2009-10-01."
+    url: "https://yaml.org/spec/1.2/spec.html"
+    type: standard
+    year: 2009
+  - authors:
+      - family-names: Hufflen
+        given-names: Jean-Michel
+    collection-title: "Proceedings of the 2006 Annual Meeting"
+    end: 253
+    month: 11
+    number: 2
+    start: 243
+    title: "Names in bibtex and mlBibTeX"
+    url: "https://www.tug.org/TUGboat/tb27-2/tb87hufflen.pdf"
+    type: proceedings
+    volume: 27
+    year: 2006

--- a/man/cff_reader.Rd
+++ b/man/cff_reader.Rd
@@ -19,8 +19,14 @@ Citation File Format (cff) reader
 CFF only supports one citation, so \code{many} will always be
 \code{FALSE}.
 
-Required fields: \code{cff-version}, \code{version}, \code{message}, \code{date-released},
-\code{title}, \code{authors}. We'll stop with error if any of these are missing
+Required fields:
+\itemize{
+\item CFF \strong{v1.1.0}: \code{cff-version}, \code{version}, \code{message}, \code{date-released},
+\code{title}, \code{authors}.
+\item CFF \strong{v1.2.0}: \code{cff-version}, \code{message}, \code{title}, \code{authors}.
+}
+
+We'll stop with error if any of these are missing.
 
 You can though have many references in your CFF file
 associated with the citation. \code{references} is an optional component in
@@ -58,13 +64,13 @@ CFF format:
 https://github.com/citation-file-format/citation-file-format
 }
 \seealso{
-Other readers: 
+Other readers:
 \code{\link{bibtex_reader}()},
 \code{\link{citeproc_reader}()},
 \code{\link{codemeta_reader}()},
 \code{\link{ris_reader}()}
 
-Other cff: 
+Other cff:
 \code{\link{cff_writer}()}
 }
 \concept{cff}

--- a/man/cff_reader.Rd
+++ b/man/cff_reader.Rd
@@ -41,7 +41,7 @@ https://github.com/citation-file-format/citation-file-format#person-objects
 }
 }
 \examples{
-(z <- system.file('extdata/citation.cff', package = "handlr"))
+(z <- system.file("extdata/citation.cff", package = "handlr"))
 res <- cff_reader(x = z)
 res
 res$cff_version
@@ -54,7 +54,7 @@ res$author
 res$references
 
 # no references
-(z <- system.file('extdata/citation-norefs.cff', package = "handlr"))
+(z <- system.file("extdata/citation-norefs.cff", package = "handlr"))
 out <- cff_reader(x = z)
 out
 out$references
@@ -64,13 +64,13 @@ CFF format:
 https://github.com/citation-file-format/citation-file-format
 }
 \seealso{
-Other readers:
+Other readers: 
 \code{\link{bibtex_reader}()},
 \code{\link{citeproc_reader}()},
 \code{\link{codemeta_reader}()},
 \code{\link{ris_reader}()}
 
-Other cff:
+Other cff: 
 \code{\link{cff_writer}()}
 }
 \concept{cff}

--- a/man/cff_writer.Rd
+++ b/man/cff_writer.Rd
@@ -29,6 +29,8 @@ adding the required CFF fields manually. Adding fields to a
 \code{handl} object is easy: it's really just an R list so add
 named elements to it. The required CFF fields are:
 \itemize{
+\item CFF \strong{v1.1.0}:
+\itemize{
 \item cff-version: add \code{cff_version}
 \item message: add \code{message}
 \item version: add \code{software_version}
@@ -36,6 +38,14 @@ named elements to it. The required CFF fields are:
 \item authors: add \code{author}
 \item date-released: add \code{date_published}
 }
+\item CFF \strong{v1.2.0}:
+\itemize{
+\item Only fields \code{cff-version}, \code{message}, \code{title} and \code{authors} are
+required.
+}
+}
+
+If \code{cff_version} is not provided, the value by default is "1.2.0".
 }
 
 \examples{

--- a/tests/testthat/test-cff_reader.R
+++ b/tests/testthat/test-cff_reader.R
@@ -4,7 +4,7 @@ z <- system.file('extdata/citation.cff', package = "handlr")
 
 test_that("cff_reader: works", {
   skip_on_cran()
-  
+
   x <- cff_reader(z)
 
   expect_is(cff_reader, "function")
@@ -33,7 +33,7 @@ test_that("cff_reader: works", {
 # main field checks
 test_that("cff_reader: required fields", {
   skip_on_cran()
-  
+
   zy <- yaml::yaml.load_file(z)
   zy$`cff-version` <- NULL
   tf <- tempfile(fileext = ".yml")
@@ -74,38 +74,143 @@ test_that("cff_reader: required fields", {
 # reference checks
 test_that("cff_reader: reference types are checked", {
   skip_on_cran()
-  
+
   zy <- yaml::yaml.load_file(z)
   zy$references[[1]]$type <- "foobar"
   tf <- tempfile(fileext = ".yml")
   yaml::write_yaml(zy, tf)
-  
+
   expect_error(cff_reader(tf), "reference")
 })
 
 test_that("cff_reader: reference title type is checked", {
   skip_on_cran()
-  
+
   zy <- yaml::yaml.load_file(z)
   zy$references[[1]]$title <- 234
   tf <- tempfile(fileext = ".yml")
   yaml::write_yaml(zy, tf)
-  
+
   expect_error(cff_reader(tf), "'title' must be a string")
 })
 
 test_that("cff_reader: reference author elements each must be entity or person", {
   skip_on_cran()
-  
+
   zy <- yaml::yaml.load_file(z)
   names(zy$references[[1]]$authors[[1]])[1] <- "foobar"
   tf <- tempfile(fileext = ".yml")
   yaml::write_yaml(zy, tf)
-  
+
   expect_error(cff_reader(tf), "each element in 'authors'")
 })
 
 test_that("cff_reader fails well", {
   expect_error(cff_reader(), "argument \"x\" is missing")
   expect_error(cff_reader(5), "x must be of class character")
+})
+
+
+test_that("cff_reader: works with 1.2.0", {
+  skip_on_cran()
+  z <- system.file("extdata/citation_1.2.0.cff", package = "handlr")
+
+  x <- cff_reader(z)
+
+  expect_is(cff_reader, "function")
+  expect_is(x, "handl")
+  expect_named(x)
+  expect_null(x[["software_version"]])
+  expect_null(x[["date_published"]])
+  expect_null(x[["key"]])
+  expect_is(x$keywords, "character")
+  expect_gt(length(x$keywords), 1)
+  expect_is(x$id, "character")
+  expect_equal(x$type, "SoftwareSourceCode")
+  expect_equal(x$bibtex_type, "misc")
+  expect_equal(x$citeproc_type, "article-journal")
+  expect_equal(x$ris_type, "COMP")
+  expect_equal(x$doi, "10.5281/zenodo.1234")
+  expect_is(x$title, "character")
+  expect_is(x$author, "list")
+  expect_is(x$author[[1]], "list")
+  expect_equal(x$author[[1]]$type, "Person")
+
+  expect_equal(attr(x, "from"), "cff")
+  expect_equal(attr(x, "source_type"), "file")
+  expect_match(attr(x, "file"), ".cff")
+  expect_false(attr(x, "many"))
+})
+
+test_that("cff_reader: works with CFF 1.2.0 original file", {
+  skip_on_cran()
+  z <- system.file("extdata/citation_1.2.0_project.cff", package = "handlr")
+
+  x <- cff_reader(z)
+  expect_is(cff_reader, "function")
+  expect_is(x, "handl")
+  expect_named(x)
+  expect_is(x[["software_version"]], "character")
+  expect_is(x[["date_published"]], "character")
+  expect_null(x[["key"]])
+  expect_is(x$keywords, "character")
+  expect_gt(length(x$keywords), 1)
+  expect_equal(x$type, "SoftwareSourceCode")
+  expect_equal(x$bibtex_type, "misc")
+  expect_equal(x$citeproc_type, "article-journal")
+  expect_equal(x$ris_type, "COMP")
+  expect_is(x$title, "character")
+  expect_is(x$author, "list")
+  expect_is(x$author[[1]], "list")
+  expect_equal(x$author[[1]]$type, "Person")
+
+  expect_equal(attr(x, "from"), "cff")
+  expect_equal(attr(x, "source_type"), "file")
+  expect_match(attr(x, "file"), ".cff")
+  expect_false(attr(x, "many"))
+})
+# main field checks
+test_that("cff_reader: required fields v1.2.0", {
+  skip_on_cran()
+  z <- system.file("extdata/citation_1.2.0.cff", package = "handlr")
+
+  zy <- yaml::yaml.load_file(z)
+  zy$`cff-version` <- NULL
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'cff-version' is required")
+
+
+  zy <- yaml::yaml.load_file(z)
+  zy$message <- NULL
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'message' is required")
+
+  zy <- yaml::yaml.load_file(z)
+  zy$title <- NULL
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'title' is required")
+
+  zy <- yaml::yaml.load_file(z)
+  zy$authors <- NULL
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'authors' is required")
+
+  # Switch to cff v1.1.0
+  zy <- yaml::yaml.load_file(z)
+  zy$`cff-version` <- "1.1.0"
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'date-released' is required")
+
+
+  zy <- yaml::yaml.load_file(z)
+  zy$`cff-version` <- "1.1.0"
+  zy$`date-released` <- "2000-01-01"
+  tf <- tempfile(fileext = ".yml")
+  yaml::write_yaml(zy, tf)
+  expect_error(cff_reader(tf), "'version' is required")
 })

--- a/tests/testthat/test-cff_writer.R
+++ b/tests/testthat/test-cff_writer.R
@@ -4,7 +4,7 @@ z <- system.file('extdata/citation.cff', package = "handlr")
 
 test_that("cff_writer: write text to stdout", {
   skip_on_cran()
-  
+
   w <- cff_reader(z)
   x <- cff_writer(w)
 
@@ -24,7 +24,7 @@ test_that("cff_writer: write text to stdout", {
 
 test_that("cff_writer: write to a file", {
   skip_on_cran()
-  
+
   w <- cff_reader(z)
   ff <- tempfile(fileext = ".yml")
   x <- cff_writer(w, ff)
@@ -32,4 +32,70 @@ test_that("cff_writer: write to a file", {
 
   expect_null(x)
   expect_identical(txt, cff_writer(w))
+})
+
+
+z2 <- system.file("extdata/citation_1.2.0.cff", package = "handlr")
+
+test_that("cff_writer 1.2.0: write text to stdout", {
+  skip_on_cran()
+
+  w <- cff_reader(z2)
+  x <- cff_writer(w)
+
+  expect_is(cff_writer, "function")
+  expect_is(w, "handl")
+  expect_is(x, "character")
+  expect_equal(length(x), 1)
+
+  # check that required fields are present
+  expect_match(x, "cff-version")
+  expect_match(x, "version")
+  expect_match(x, "message")
+  expect_no_match(x, "date-released")
+  expect_match(x, "title")
+  expect_match(x, "authors")
+})
+
+test_that("cff_writer 1.2.0: write to a file", {
+  skip_on_cran()
+
+  w <- cff_reader(z2)
+  ff <- tempfile(fileext = ".yml")
+  x <- cff_writer(w, ff)
+  txt <- paste0(readLines(ff), collapse = "\n")
+
+  expect_null(x)
+  expect_identical(txt, cff_writer(w))
+})
+
+
+z2 <- system.file("extdata/citation_1.2.0_project.cff", package = "handlr")
+
+test_that("cff_writer 1.2.0 project: write text to stdout", {
+  skip_on_cran()
+
+  w <- cff_reader(z2)
+  x <- cff_writer(w)
+
+  expect_is(cff_writer, "function")
+  expect_is(w, "handl")
+  expect_is(x, "character")
+  expect_equal(length(x), 1)
+
+  # check that required fields are present
+  expect_match(x, "cff-version")
+  expect_match(x, "version")
+  expect_match(x, "message")
+  expect_match(x, "title")
+  expect_match(x, "authors")
+})
+
+test_that("cff_writer 1.2.0 project: write to a file", {
+  skip_on_cran()
+
+  w <- cff_reader(z2)
+  ff <- tempfile(fileext = ".yml")
+  x <- cff_writer(w, ff)
+  expect_null(x)
 })

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -70,7 +70,6 @@ test_that("HandlrClient class: works with DOIs", {
 
   # result from DOI and DOI as url the same
   expect_identical(a$parsed, b$parsed)
-  a$write('bibtex')
   # can convert to bibtex
   expect_true(any(grepl("journal = \\{eLife\\}", a$write('bibtex'))))
 

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -70,9 +70,9 @@ test_that("HandlrClient class: works with DOIs", {
 
   # result from DOI and DOI as url the same
   expect_identical(a$parsed, b$parsed)
-
+  a$write('bibtex')
   # can convert to bibtex
-  expect_true(any(grepl("\\@article", a$write('bibtex'))))
+  expect_true(any(grepl("journal = \\{eLife\\}", a$write('bibtex'))))
 
   # fails as expected
   expect_error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds support for the latest version of CFF ([v1.2.0](https://github.com/citation-file-format/citation-file-format/tree/1.2.0)). It is also compatible with v1.1.0. 

## Description
- Add support to both CFF v1.1.0 and CFF v1.2.0.
- Default `cff-version` on `cff_writer()` is now **v1.2.0**.
- Additionally:
   - GitHub Actions have been updated: see https://github.com/r-lib/actions/tree/master/examples
   - A test was failing on my PC. I think it is due to the test design: I tried to make it more robust, not requiring a specific BibTex entry type, but just that the information is present.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Closes #24 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library(handlr)

# Minimal cff with v1.2.0 required keys only
file <- system.file("extdata/citation_1.2.0.cff", package = "handlr")
new <- cff_reader(file)
cat(cff_writer(new))
#> cff-version: 1.2.0
#> message: If you use this software, please cite it as below.
#> title: My Research Software
#> authors:
#> - family-names: Druskat
#>   given-names: Stephan
#>   orcid: https://orcid.org/0000-0003-4925-7248
#> doi: 10.5281/zenodo.1234
#> keywords:
#> - McAuthor's algorithm
#> - linguistics
#> - nlp
#> - parser
#> references:
#> - type: book
#>   authors:
#>   - family-names: Doe
#>     given-names: Jane
#>   - name: Foo Bar Working Group
#>     website: https://foo-bar.com
#>   title: The science of citation
#> - type: software
#>   authors:
#>   - family-names: Doe
#>     given-names: John
#>   title: Software Citation Tool
cat(bibtex_writer(new), sep = "\n")
#> @misc{10.5281/zenodo.1234,
#>   doi = {10.5281/zenodo.1234},
#>   author = {Stephan Druskat},
#>   title = {My Research Software},
#>   pages = {},
#> }
# When switched to cff_v1 it would still fail


zy <- yaml::yaml.load_file(file)
zy$`cff-version` <- "1.1.0"
tf <- tempfile(fileext = ".yml")
yaml::write_yaml(zy, tf)
cff_reader(tf)
#> Error: 'date-released' is required
```

<sup>Created on 2021-09-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
